### PR TITLE
Add hook to create partial backend configuration

### DIFF
--- a/live/global/terraform-remote-state/terragrunt.hcl
+++ b/live/global/terraform-remote-state/terragrunt.hcl
@@ -3,6 +3,6 @@ terraform {
 }
 
 inputs = {
-  bucket         = chomp(run_cmd("../../../config/config.sh", "BUCKET"))
-  dynamodb_table = chomp(run_cmd("../../../config/config.sh", "DYNAMODB_TABLE"))
+  bucket         = chomp(run_cmd("../../../scripts/config.sh", "BUCKET"))
+  dynamodb_table = chomp(run_cmd("../../../scripts/config.sh", "DYNAMODB_TABLE"))
 }

--- a/live/terragrunt.hcl
+++ b/live/terragrunt.hcl
@@ -3,15 +3,21 @@ remote_state {
   backend = "s3"
 
   config = {
-    bucket         = chomp(run_cmd("${path_relative_from_include()}/../config/config.sh", "BUCKET"))
-    region         = chomp(run_cmd("${path_relative_from_include()}/../config/config.sh", "REGION"))
-    dynamodb_table = chomp(run_cmd("${path_relative_from_include()}/../config/config.sh", "DYNAMODB_TABLE"))
+    bucket         = chomp(run_cmd("${path_relative_from_include()}/../scripts/config.sh", "BUCKET"))
+    region         = chomp(run_cmd("${path_relative_from_include()}/../scripts/config.sh", "REGION"))
+    dynamodb_table = chomp(run_cmd("${path_relative_from_include()}/../scripts/config.sh", "DYNAMODB_TABLE"))
     key            = "${path_relative_to_include()}/terraform.tfstate"
     encrypt        = true
   }
 }
 
 terraform {
+  after_hook "init_from_module" {
+    commands = ["init-from-module"]
+    #execute  = ["${path_relative_from_include()}/../scripts/after_hooks_init_from_module.sh"]
+    execute = ["ln", "-sf", "../../backend.tf", "."]
+  }
+
   extra_arguments "env_vars" {
     commands = [
       "init",

--- a/live/terragrunt.hcl
+++ b/live/terragrunt.hcl
@@ -14,8 +14,7 @@ remote_state {
 terraform {
   after_hook "init_from_module" {
     commands = ["init-from-module"]
-    #execute  = ["${path_relative_from_include()}/../scripts/after_hooks_init_from_module.sh"]
-    execute = ["ln", "-sf", "../../backend.tf", "."]
+    execute  = ["ln", "-sf", "../../backend.tf", "."]
   }
 
   extra_arguments "env_vars" {

--- a/scripts/after_hooks_init_from_module.sh
+++ b/scripts/after_hooks_init_from_module.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ ! -f "backend.tf" ]; then
+	ln -s ../../backend.tf .
+fi

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -8,7 +8,7 @@ syntax() {
 print_config() {
   cd "$(dirname "${BASH_SOURCE[0]}")" || exit
 
-  x="$(grep ^"$1" ./remote_state.config)"
+  x="$(grep ^"$1" ../config/remote_state.config)"
   if [ "$x" ]; then
   	echo "$x" | cut -d'=' -f2
   else


### PR DESCRIPTION
The Goal: Have terragrunt automatically create partial backend configuration, rather than manually `cp` or `ln -s` the file to each directory 😢 .  Credit goes to @lsc for the idea

- [x] Add the `after_hook` to create the backend.tf
- [x] Add the very simple one-liner script to do the `ln -s backend.tf`
- [x] Sneaking in another change: Add `scripts/` directory and move existing script into it/reorganize a bit

- [x] I might come back and just call the `ln` command straight from the `execute` line. We'll see how I feel in the morning